### PR TITLE
Add check TypeScript command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Compile TypeScript
-        run: tsc
+        run: npm run checkTs
   test:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "NODE_ICU_DATA=node_modules/full-icu next build",
+    "checkTs": "tsc --noEmit",
     "format": "prettier --write .",
     "lint": "eslint --max-warnings 0 --ext .ts --ext .tsx --ext .js --ext .jsx src/",
     "lint:fix": "eslint --max-warnings 0 --fix --ext .ts --ext .tsx --ext .js --ext .jsx src/",


### PR DESCRIPTION
I noticed there were several TypeScript errors on #44, so I thought it would be handy to have a command to see those since it seems NextJS doesn't expose them.