### PR TITLE
Disable non-hover link prefetching across the site

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,5 +21,6 @@ module.exports = {
 				ast: true,
 			},
 		],
+		'./babel/disable-nextjs-link-prefetching',
 	],
 };

--- a/babel/disable-nextjs-link-prefetching.js
+++ b/babel/disable-nextjs-link-prefetching.js
@@ -1,0 +1,28 @@
+// SOURCE: https://github.com/vercel/next.js/discussions/24009#discussioncomment-1159779
+
+/**
+ * Based on the docs at https://nextjs.org/docs/api-reference/next/link, the
+ * only way to disable prefetching is to make sure every <Link /> has <Link
+ * prefetch={false} />
+ *
+ * We don't want to create a wrapper Component or go around changing every
+ * single <Link />, so we use this Babel Plugin to add them in at build-time.
+ */
+module.exports = function (babel) {
+	const { types: t } = babel;
+	return {
+		name: 'disable-link-prefetching',
+		visitor: {
+			JSXOpeningElement(path) {
+				if (path.node.name.name === 'Link') {
+					path.node.attributes.push(
+						t.jSXAttribute(
+							t.jSXIdentifier('prefetch'),
+							t.JSXExpressionContainer(t.booleanLiteral(false))
+						)
+					);
+				}
+			},
+		},
+	};
+};


### PR DESCRIPTION
Fixes https://trello.com/c/MGJdSuNt/140-tune-link-preloading, and (I believe!) https://trello.com/c/vbjAcPN4/95-404-on-non-built-presenter-pages.