### PR TITLE
Fix invalid date error on null recordingDate

### DIFF
--- a/src/components/organisms/recording.tsx
+++ b/src/components/organisms/recording.tsx
@@ -71,9 +71,9 @@ export function Recording({ recording }: RecordingProps): JSX.Element {
 
 	const isAudiobook = contentType === RecordingContentType.AudiobookTrack;
 	const persons = isAudiobook ? writers : speakers;
-	const recordingDateString = formatLongDateTime(
-		parseRelativeDate(recordingDate || '') || ''
-	);
+	const recordingDateString = recordingDate
+		? formatLongDateTime(parseRelativeDate(recordingDate) || '')
+		: undefined;
 	const index = sequenceIndex;
 	const seriesItems = sequence?.recordings?.nodes;
 


### PR DESCRIPTION
On `/en/stories/16718/08-changed-hearts` fixes:

<img width="777" alt="image" src="https://user-images.githubusercontent.com/120155/140203025-c2f9e41d-9bc7-4386-af6a-b15be2b98dbc.png">

