### PR TITLE
Use public environment variable for API URL

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,1 +1,2 @@
+NEXT_PUBLIC_API_URL="https://graphql.audioverse.org/graphql"
 BIBLE_BRAIN_KEY=abc123

--- a/src/lib/api/fetchApi.ts
+++ b/src/lib/api/fetchApi.ts
@@ -2,13 +2,12 @@ import { parse } from 'graphql';
 import { print } from 'graphql/language/printer';
 
 import { getCurrentRequest } from '@lib/api/storeRequest';
-import { IS_PRODUCTION_DEPLOYMENT } from '@lib/constants';
 import { getSessionToken } from '@lib/cookies';
 import { sleep } from '@lib/sleep';
 
-const API_URL = IS_PRODUCTION_DEPLOYMENT
-	? 'https://graphql.audioverse.org/graphql'
-	: 'https://graphql-staging.audioverse.org/graphql';
+const API_URL =
+	process.env.NEXT_PUBLIC_API_URL ||
+	'https://graphql-staging.audioverse.org/graphql';
 
 // WORKAROUND
 // Graphql Code Generator duplicates fragment definitions


### PR DESCRIPTION
(Hopefully) fixes staging data used client-side on beta.av.org. https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser