### PR TITLE
Disable pointer events for non-interactive progress bar

### DIFF
--- a/src/components/atoms/progressBar.module.scss
+++ b/src/components/atoms/progressBar.module.scss
@@ -43,3 +43,7 @@
 		}
 	}
 }
+
+.pointerDisabled {
+	pointer-events: none;
+}

--- a/src/components/atoms/progressBar.tsx
+++ b/src/components/atoms/progressBar.tsx
@@ -18,7 +18,14 @@ export default function ProgressBar({
 	const intl = useIntl();
 	const cssProps = { '--progress': `${progress * 100}%` } as CSSProperties;
 	return (
-		<span className={clsx(styles.progress, className)} style={cssProps}>
+		<span
+			className={clsx(
+				styles.progress,
+				className,
+				!setProgress && styles.pointerDisabled
+			)}
+			style={cssProps}
+		>
 			<input
 				type="range"
 				value={progress * 100}

--- a/src/components/organisms/recording.module.scss
+++ b/src/components/organisms/recording.module.scss
@@ -43,6 +43,7 @@
 	--headingColor: var(--recordingTextColor);
 	--cardColor: var(--recordingTextSecondaryColor);
 	--partColor: var(--recordingAccent);
+	--progressColor: var(--recordingAccent);
 }
 
 .hat {


### PR DESCRIPTION
Fixes https://trello.com/c/hjzukFVT/169-pointer-doesnt-indicate-progress-bar-in-card-is-clickable-but-clicking-opens-recording-confusing.