### PR TITLE
Fix incorrect video filter selection

### DIFF
--- a/src/containers/sermon/list.tsx
+++ b/src/containers/sermon/list.tsx
@@ -80,7 +80,7 @@ function SermonList({ nodes, pagination, filter }: SermonListProps) {
 								<a
 									className={clsx(
 										styles.segmentedControl,
-										filter === 'filter' && styles.segmentedControlActive
+										filter === 'video' && styles.segmentedControlActive
 									)}
 								>
 									<FormattedMessage


### PR DESCRIPTION
Fixes https://trello.com/c/mxk7WMzC/272-recordings-filter-doesnt-highlight-video-when-its-selected.