### PR TITLE
Start background video playback in miniplayer

### DIFF
--- a/src/components/templates/andMiniplayer.tsx
+++ b/src/components/templates/andMiniplayer.tsx
@@ -53,7 +53,7 @@ export default function AndMiniplayer({
 			>
 				{children}
 			</div>
-			{recording && <LazyMiniplayer />}
+			<LazyMiniplayer />
 		</>
 	);
 }


### PR DESCRIPTION
Fixes https://trello.com/c/Oa8nNWMy/271-miniplayer-controls-should-always-be-visible-unless-video-is-playing-in-miniplayer.