### PR TITLE
Attempt to fix Bible not playing on Android

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -37,7 +37,7 @@ module.exports = withBundleAnalyzer(
 				...Object.keys(languagePrefixMap).map((prefix) => ({
 					source: `/${prefix}/:path*`,
 					destination: `/${languagePrefixMap[prefix]}/:path*`,
-					permanent: true,
+					statusCode: 301,
 				})),
 				...Object.keys(languagePrefixMap).map((prefix) => ({
 					source: '/',


### PR DESCRIPTION
Attempt to fix https://trello.com/c/ot17Ug1f/270-android-app-wont-play-the-bible-anymore. This replaces the default permanent status code (`308`) with `301` on the main language slug redirect. The `301` code is supported in basically any client in existence, vs. `308` only being supported in non-legacy clients (hopefully such as Android).