### PR TITLE
Increase fallback donate box height

### DIFF
--- a/src/containers/give.tsx
+++ b/src/containers/give.tsx
@@ -22,12 +22,12 @@ export default function Blog(): JSX.Element {
 				{/* WORKAROUND: https://stackoverflow.com/a/55322126/937377 */}
 				<script
 					src="https://donorbox.org/widget.js"
-					async={true}
+					async
 					{...{ paypalexpress: 'true' }}
 				/>
 				<iframe
 					src="https://donorbox.org/embed/audioverse-give?hide_donation_meter=true&designation=Where%20Needed%20Most"
-					height="685px"
+					height="1100px"
 					width="100%"
 					style={{
 						maxWidth: '400px',

--- a/src/containers/give.tsx
+++ b/src/containers/give.tsx
@@ -20,9 +20,9 @@ export default function Blog(): JSX.Element {
 					<FormattedMessage id="give__heading" defaultMessage="Donate" />
 				</Heading1>
 				{/* WORKAROUND: https://stackoverflow.com/a/55322126/937377 */}
+				{/* eslint-disable-next-line @next/next/no-sync-scripts */}
 				<script
 					src="https://donorbox.org/widget.js"
-					async
 					{...{ paypalexpress: 'true' }}
 				/>
 				<iframe


### PR DESCRIPTION
Maybe fixes https://trello.com/c/hH8ziDV5/288-donate-form-cut-off. Donorbox has a JS script that sets the height of the iframe based on which tab is actually showing. This seems to be working in most cases. However perhaps this user has some issue running that JS and increasing the default (fallback) height seems like a potential solution.