### PR TITLE
Hide persons on sequence cards with recordings

### DIFF
--- a/src/components/molecules/card/sequence.tsx
+++ b/src/components/molecules/card/sequence.tsx
@@ -191,7 +191,10 @@ export default function CardSequence({
 					></div>
 				)}
 				{!!persons.length &&
-					sequence.contentType !== SequenceContentType.BibleBook && (
+					sequence.contentType !== SequenceContentType.BibleBook &&
+					(!recordings?.length ||
+						sequence.contentType === SequenceContentType.Audiobook ||
+						sequence.contentType === SequenceContentType.MusicAlbum) && (
 						<div className={styles.persons}>
 							{(personsExpanded ? persons : persons.slice(0, 2)).map((p) => (
 								<PersonLockup


### PR DESCRIPTION
This change matches the Figma designs.

Before:

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/120155/155562108-84dbabbb-7fba-4343-8e9c-63a400569197.png">

After:

<img width="1288" alt="image" src="https://user-images.githubusercontent.com/120155/155562140-c7368c13-75ad-4144-ad2d-65b35614e86a.png">
