### PR TITLE
Attempt to fix Bible versions list page 404ing

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,7 +1,8 @@
 {
 	"low": true,
 	"allowlist": [
-		1059402, // Not used at runtime
-		1059599 // Not used at runtime
+		1064646, // Not used at runtime
+		1064843, // Not used at runtime
+		1067285 // Not used at runtime
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18073,9 +18073,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "masonic": "^3.6.1",
     "next": "^12.1.0",
     "next-pwa": "^5.4.4",
-    "node-forge": "^1.2.1",
+    "node-forge": "^1.3.0",
     "normalize.css": "^8.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/pages/[language]/bibles/[id]/[book]/[chapter].tsx
+++ b/src/pages/[language]/bibles/[id]/[book]/[chapter].tsx
@@ -39,6 +39,7 @@ export async function getStaticProps({
 	if (!bibleBook) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 	const chapters = await getBibleBookChapters(id, bibleBook.testament, book);

--- a/src/pages/[language]/bibles/index.tsx
+++ b/src/pages/[language]/bibles/index.tsx
@@ -28,17 +28,18 @@ export async function getStaticProps({
 		language: getLanguageIdByRoute(params?.language),
 	}).catch(() => ({ collections: { nodes: [] } }));
 
-	if (!response || !apiBibles?.collections.nodes) {
+	if (!apiBibles?.collections.nodes) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 
 	const intl = await getIntl(getLanguageIdByRoute(params?.language));
 	return {
 		props: {
-			versions: [...response, ...apiBibles.collections.nodes].sort((a, b) =>
-				a.title.localeCompare(b.title)
+			versions: [...(response || []), ...apiBibles.collections.nodes].sort(
+				(a, b) => a.title.localeCompare(b.title)
 			),
 			title: intl.formatMessage({
 				id: 'bible__title',

--- a/src/pages/[language]/blog/[id]/[[...slugs]].ts
+++ b/src/pages/[language]/blog/[id]/[[...slugs]].ts
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import BlogPostDetail, { BlogPostDetailProps } from '@containers/blog/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getBlogDetailData,
 	getBlogDetailStaticPaths,
@@ -32,6 +32,7 @@ export async function getStaticProps({
 	if (blogPost?.language !== routeLanguage) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/books/[id]/[[...slugs]].tsx
+++ b/src/pages/[language]/books/[id]/[[...slugs]].tsx
@@ -8,7 +8,7 @@ import AudiobookDetail, {
 	AudiobookDetailProps,
 } from '@containers/audiobook/detail';
 import { IBaseProps } from '@containers/base';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getAudiobookDetailPageData,
 	getAudiobookDetailPathsData,
@@ -35,6 +35,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/books/tracks/[id]/[[...slugs]].tsx
+++ b/src/pages/[language]/books/tracks/[id]/[[...slugs]].tsx
@@ -8,7 +8,7 @@ import AudiobookTrackDetail, {
 	AudiobookTrackDetailProps,
 } from '@containers/audiobook/tracks/detail';
 import { IBaseProps } from '@containers/base';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getAudiobookTrackDetailData,
 	getAudiobookTrackDetailStaticPaths,
@@ -35,6 +35,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/conferences/[id]/[[...slug]].tsx
+++ b/src/pages/[language]/conferences/[id]/[[...slug]].tsx
@@ -8,7 +8,7 @@ import { IBaseProps } from '@containers/base';
 import CollectionDetail, {
 	CollectionDetailProps,
 } from '@containers/collection/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getCollectionDetailPageData,
 	getCollectionDetailPathsData,
@@ -34,6 +34,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 	return {

--- a/src/pages/[language]/embed/media/[id].ts
+++ b/src/pages/[language]/embed/media/[id].ts
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import SermonEmbed, { SermonEmbedProps } from '@containers/sermon/embed';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getSermonDetailData,
 	getSermonDetailStaticPaths,
@@ -35,6 +35,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/presenters/[id]/[[...slug]].tsx
+++ b/src/pages/[language]/presenters/[id]/[[...slug]].tsx
@@ -8,7 +8,7 @@ import { IBaseProps } from '@containers/base';
 import PresenterDetail, {
 	PresenterDetailProps,
 } from '@containers/presenter/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getPresenterDetailPageData,
 	getPresenterDetailPathsData,
@@ -47,6 +47,7 @@ export async function getStaticProps({
 	if (result.person?.language !== routeLanguage) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/presenters/[id]/top.ts
+++ b/src/pages/[language]/presenters/[id]/top.ts
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import PresenterTop, { PresenterTopProps } from '@containers/presenter/top';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getPresenterDetailPathsData,
 	getPresenterTopPageData,
@@ -37,6 +37,7 @@ export async function getStaticProps({
 	if (person?.language !== language) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/series/[id]/[[...slug]].tsx
+++ b/src/pages/[language]/series/[id]/[[...slug]].tsx
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import SeriesDetail, { SeriesDetailProps } from '@containers/series/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getSeriesDetailPageData,
 	getSeriesDetailPathsData,
@@ -32,6 +32,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/songs/[id]/[[...slugs]].ts
+++ b/src/pages/[language]/songs/[id]/[[...slugs]].ts
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import SongDetail, { SongDetailProps } from '@containers/song/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getSongDetailData,
 	getSongDetailStaticPaths,
@@ -32,6 +32,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/songs/albums/[id]/[[...slugs]].tsx
+++ b/src/pages/[language]/songs/albums/[id]/[[...slugs]].tsx
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import Song, { SongAlbumDetailProps } from '@containers/song/albums/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getSongAlbumsDetailPageData,
 	getSongAlbumsDetailPathsData,
@@ -33,6 +33,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/songs/book/[book]/[id]/[[...slugs]].ts
+++ b/src/pages/[language]/songs/book/[book]/[id]/[[...slugs]].ts
@@ -8,7 +8,7 @@ import { IBaseProps } from '@containers/base';
 import SongBookTrack, {
 	SongBookTrackProps,
 } from '@containers/song/books/track';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import { getBookSongDetailData } from '@lib/generated/graphql';
 import { getLanguageIdByRoute } from '@lib/getLanguageIdByRoute';
 
@@ -34,6 +34,7 @@ export async function getStaticProps({
 	if (recording?.language !== languageRoute) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/sponsors/[id]/[[...slugs]].tsx
+++ b/src/pages/[language]/sponsors/[id]/[[...slugs]].tsx
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import SponsorDetail, { SponsorDetailProps } from '@containers/sponsor/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getSponsorDetailPageData,
 	getSponsorDetailPathsData,
@@ -30,6 +30,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/stories/[id]/[[...slugs]].tsx
+++ b/src/pages/[language]/stories/[id]/[[...slugs]].tsx
@@ -6,7 +6,7 @@ import {
 
 import { IBaseProps } from '@containers/base';
 import Story, { StoryDetailProps } from '@containers/story/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getStoryDetailData,
 	getStoryDetailStaticPaths,
@@ -32,6 +32,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/stories/albums/[id]/[[...slugs]].tsx
+++ b/src/pages/[language]/stories/albums/[id]/[[...slugs]].tsx
@@ -8,7 +8,7 @@ import { IBaseProps } from '@containers/base';
 import StoryAlbumDetail, {
 	StoryAlbumDetailProps,
 } from '@containers/story/albums/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getStoryAlbumDetailPageData,
 	getStoryAlbumDetailPathsData,
@@ -35,6 +35,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/teachings/[id]/[[...slug]].ts
+++ b/src/pages/[language]/teachings/[id]/[[...slug]].ts
@@ -7,7 +7,7 @@ import striptags from 'striptags';
 
 import { IBaseProps } from '@containers/base';
 import SermonDetail, { SermonDetailProps } from '@containers/sermon/detail';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import {
 	getSermonDetailData,
 	getSermonDetailStaticPaths,
@@ -36,6 +36,7 @@ export async function getStaticProps({
 	) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 

--- a/src/pages/[language]/teachings/trending/all.ts
+++ b/src/pages/[language]/teachings/trending/all.ts
@@ -7,7 +7,7 @@ import {
 import { IBaseProps } from '@containers/base';
 import TrendingTeachings from '@containers/sermon/trending';
 import { TrendingTeachingsProps } from '@containers/sermon/trending';
-import { REVALIDATE } from '@lib/constants';
+import { REVALIDATE, REVALIDATE_FAILURE } from '@lib/constants';
 import { getTrendingTeachingsPageData } from '@lib/generated/graphql';
 import getIntl from '@lib/getIntl';
 import { getLanguageIdByRoute } from '@lib/getLanguageIdByRoute';
@@ -26,6 +26,7 @@ export async function trendingStaticProps(
 	if (!['all', 'audio', 'video'].includes(filter)) {
 		return {
 			notFound: true,
+			revalidate: REVALIDATE_FAILURE,
 		};
 	}
 


### PR DESCRIPTION
The default value of `revalidate` is `false ([ref](https://nextjs.org/docs/api-reference/data-fetching/get-static-props#revalidate)) which would mean that if any API were unavailable when the page was rendered that 404 would be cached indefinitely.

See also https://github.com/vercel/next.js/issues/25907#issuecomment-857267054