### PR TITLE
Enable ASI Scandinavian route w/o button option

### DIFF
--- a/src/components/molecules/languageButton.tsx
+++ b/src/components/molecules/languageButton.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 
 import { LANGUAGES } from '@lib/constants';
+import { Language } from '@lib/generated/graphql';
 import { getLanguageIdByRoute } from '@lib/getLanguageIdByRoute';
 import getLanguageIds from '@lib/getLanguageIds';
 import useLanguageRoute from '@lib/useLanguageRoute';
@@ -27,7 +28,7 @@ export default function LanguageButton({
 	const languageRoute = useLanguageRoute();
 	const languageId = getLanguageIdByRoute(languageRoute);
 
-	const languageIds = getLanguageIds();
+	const languageIds = getLanguageIds().filter((l) => l !== Language.Nordic);
 
 	return (
 		<Dropdown

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,7 +8,7 @@ export interface LanguageConfiguration {
 	legacy_base_url: string;
 }
 
-export type SupportedLanguages = Exclude<Language, 'NORDIC'>;
+export type SupportedLanguages = Language;
 
 export type LanguageConfigurations = {
 	[key in SupportedLanguages]: LanguageConfiguration;
@@ -49,6 +49,11 @@ export const LANGUAGES: LanguageConfigurations = {
 		base_url: 'ru',
 		display_name: 'Русский',
 		legacy_base_url: 'russian',
+	},
+	NORDIC: {
+		base_url: 'no',
+		display_name: 'Scandinavia',
+		legacy_base_url: 'no',
 	},
 };
 


### PR DESCRIPTION
ASI Scandinavia is ready to start adding content, but we're going to wait to link them until they're ready to launch. Refs https://github.com/avorg/audioverse-next/pull/177/commits/27e1181f8a9ae0838f3ccd4b3d1b58f0ba9894ea