### PR TITLE
Nix sponsor fallback image on collection detail

### DIFF
--- a/src/components/HOCs/withIntl.spec.tsx
+++ b/src/components/HOCs/withIntl.spec.tsx
@@ -388,7 +388,7 @@ describe('localization usage', () => {
 						id: '234',
 						title: 'z',
 						canonicalPath: '...',
-						imageWithFallback: {
+						image: {
 							url: '',
 						},
 					},

--- a/src/components/molecules/namedAvatar.module.scss
+++ b/src/components/molecules/namedAvatar.module.scss
@@ -6,9 +6,12 @@
 }
 
 .title {
-	margin-left: 8px;
 	font-size: 16px;
 	line-height: 19.36px;
+}
+
+.titleWithImage {
+	margin-left: 8px;
 }
 
 .link {

--- a/src/components/molecules/namedAvatar.tsx
+++ b/src/components/molecules/namedAvatar.tsx
@@ -34,7 +34,9 @@ export default function NamedAvatar({
 	const inner = (
 		<>
 			{image && <RoundImage image={image} small={small} />}
-			<div className={styles.title}>{name}</div>
+			<div className={clsx(styles.title, image && styles.titleWithImage)}>
+				{name}
+			</div>
 		</>
 	);
 	const containerClasses = clsx(styles.container, baseColorStyles[textColor]);

--- a/src/components/molecules/sponsorLockup.graphql
+++ b/src/components/molecules/sponsorLockup.graphql
@@ -2,7 +2,7 @@ fragment sponsorLockup on Sponsor {
 	id
 	title
 	canonicalPath(useFuturePath: true)
-	imageWithFallback {
+	image {
 		url(size: 128)
 	}
 }

--- a/src/components/molecules/sponsorLockup.tsx
+++ b/src/components/molecules/sponsorLockup.tsx
@@ -10,14 +10,14 @@ type Props = {
 } & Omit<INamedAvatarProps, 'name' | 'image' | 'href'>;
 
 export default function SponsorLockup({
-	sponsor: { title, imageWithFallback, canonicalPath },
+	sponsor: { title, image, canonicalPath },
 	isLinked,
 	...props
 }: Props): JSX.Element {
 	return (
 		<NamedAvatar
 			name={title}
-			image={imageWithFallback.url}
+			image={image?.url}
 			href={isLinked ? canonicalPath : undefined}
 			{...props}
 		/>

--- a/src/lib/generated/graphql.ts
+++ b/src/lib/generated/graphql.ts
@@ -6660,7 +6660,7 @@ export type SponsorLockupFragment = {
 	id: string | number;
 	title: string;
 	canonicalPath: string;
-	imageWithFallback: { __typename?: 'Image'; url: string };
+	image: { __typename?: 'Image'; url: string } | null;
 };
 
 export type TeaseRecordingFragment = {
@@ -8201,7 +8201,7 @@ export type GetCollectionDetailPageDataQuery = {
 			id: string | number;
 			title: string;
 			canonicalPath: string;
-			imageWithFallback: { __typename?: 'Image'; url: string };
+			image: { __typename?: 'Image'; url: string } | null;
 		} | null;
 		persons: {
 			__typename?: 'PersonConnection';
@@ -14051,7 +14051,7 @@ export const CopyrightInfosFragmentDoc = `
 fragment copyrightInfos on Recording{id copyrightYear distributionAgreement{id}sponsor{id}...copyrightInfo}
 `;
 export const SponsorLockupFragmentDoc = `
-fragment sponsorLockup on Sponsor{id title canonicalPath(useFuturePath:true)imageWithFallback{url(size:128)}}
+fragment sponsorLockup on Sponsor{id title canonicalPath(useFuturePath:true)image{url(size:128)}}
 `;
 export const SequenceNavFragmentDoc = `
 fragment sequenceNav on Recording{sequencePreviousRecording{canonicalPath(useFuturePath:true)}sequenceNextRecording{canonicalPath(useFuturePath:true)}}


### PR DESCRIPTION
E.g. here: https://www.audioverse.org/en/conferences/343/adagra-2019-true-success