### PR TITLE
Fix summary line-height to avoid truncation

### DIFF
--- a/src/containers/presenter/list.module.scss
+++ b/src/containers/presenter/list.module.scss
@@ -52,6 +52,7 @@
 	margin-top: 8px;
 	color: $ts-midTone;
 	font-size: 16px;
+	line-height: 1.21;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Fixes [this](https://www.audioverse.org/en/presenters):

<img width="744" alt="image" src="https://user-images.githubusercontent.com/120155/193616514-c00cef98-9612-44ee-8fc8-eaba8f1351e5.png">
