### PR TITLE
Fix audit failure

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -4,6 +4,7 @@
 		"GHSA-xvch-5gv4-984h", // Not used at runtime
 		"GHSA-93q8-gq69-wqmw", // Not used at runtime
 		"GHSA-pfrx-2q88-qq97", // Not used at runtime
-		"GHSA-xvf7-4v9q-58w6" // Not used at runtime
+		"GHSA-xvf7-4v9q-58w6", // Not used at runtime
+		"GHSA-9pgh-qqpf-7wqj" // Not used at runtime
 	]
 }


### PR DESCRIPTION
`mpd-parser` and therefore `xmldom` is not used.