### PR TITLE
add e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,54 +57,6 @@ jobs:
         run: |
           echo "The following files are not formatted:"
           echo "${{steps.prettier-run.outputs.prettier_output}}"
-  lighthouse:
-    runs-on: ubuntu-latest
-    permissions:
-      checks: read
-      pull-requests: write
-    steps:
-      # WORKAROUND: https://github.com/treosh/lighthouse-ci-action/issues/21
-      - uses: actions/checkout@v1
-      - name: Delete default configuration
-        run: rm .lighthouserc.yaml
-      - name: Wait for Vercel preview URL
-        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
-        id: waitFor200
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 1200
-          check_interval: 10
-      - name: Run Lighthouse
-        uses: treosh/lighthouse-ci-action@v9
-        id: lighthouse
-        with:
-          urls: |
-            ${{steps.waitFor200.outputs.url}}/
-            ${{steps.waitFor200.outputs.url}}/en
-            ${{steps.waitFor200.outputs.url}}/es
-            ${{steps.waitFor200.outputs.url}}/en/discover
-            ${{steps.waitFor200.outputs.url}}/en/teachings/all/page/1
-            ${{steps.waitFor200.outputs.url}}/en/teachings/300
-            ${{steps.waitFor200.outputs.url}}/en/bibles
-            ${{steps.waitFor200.outputs.url}}/en/presenters/1309/amanda-anguish
-          runs: 3
-          uploadArtifacts: true
-          temporaryPublicStorage: true
-      - name: Format comment
-        uses: actions/github-script@v6
-        id: formatComment
-        with:
-          script: |
-            const parsed = JSON.parse('${{steps.lighthouse.outputs.links}}');
-            const keys = Object.keys(parsed);
-            const lines = keys.map(k => `- [${k}](${parsed[k]})`);
-            return `# Lighthouse Results\n\n${lines.join('\n')}`;
-          result-encoding: string
-      - name: Add comment
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: ${{steps.formatComment.outputs.result}}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,45 @@
+name: E2E
+on: [deployment_status]
+jobs:
+  lighthouse:
+    if: github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      pull-requests: write
+    steps:
+      # WORKAROUND: https://github.com/treosh/lighthouse-ci-action/issues/21
+      - uses: actions/checkout@v2
+      - name: Delete default configuration
+        run: rm .lighthouserc.yaml
+      - name: Run Lighthouse
+        uses: treosh/lighthouse-ci-action@v9
+        id: lighthouse
+        with:
+          urls: |
+            ${{github.event.deployment_status.target_url}}/
+            ${{github.event.deployment_status.target_url}}/en
+            ${{github.event.deployment_status.target_url}}/es
+            ${{github.event.deployment_status.target_url}}/en/discover
+            ${{github.event.deployment_status.target_url}}/en/teachings/all/page/1
+            ${{github.event.deployment_status.target_url}}/en/teachings/300
+            ${{github.event.deployment_status.target_url}}/en/bibles
+            ${{github.event.deployment_status.target_url}}/en/presenters/1309/amanda-anguish
+          runs: 3
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+      - name: Format comment
+        uses: actions/github-script@v6
+        id: formatComment
+        with:
+          script: |
+            const parsed = JSON.parse('${{steps.lighthouse.outputs.links}}');
+            const keys = Object.keys(parsed);
+            const lines = keys.map(k => `- [${k}](${parsed[k]})`);
+            return `# Lighthouse Results\n\n${lines.join('\n')}`;
+          result-encoding: string
+      - name: Add comment
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: ${{steps.formatComment.outputs.result}}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously, the Lighthouse check triggered immediately and then waited until the Vercel build succeeded before checking the pages. This could result in timeouts if multiple Vercel builds were queued.

This PR creates a separate E2E workflow that is only triggered once the Vercel deployment has succeeded, thereby making it unnecessary for the Lighthouse check to do any waiting itself.