### PR TITLE
Localize AndNavigation layout

### DIFF
--- a/src/components/organisms/drawer.module.scss
+++ b/src/components/organisms/drawer.module.scss
@@ -6,7 +6,7 @@
 
 .navigation {
     position: fixed;
-    height: 100%;
+    height: 100vh;
     width: 100vw;
     top: 0;
     display: flex;
@@ -34,7 +34,7 @@
     }
 
     .navigation {
-        position: fixed;
+        position: static;
         width: $sidebar-width;
         padding: 0;
         overflow: scroll;

--- a/src/components/organisms/mobileHeader.module.scss
+++ b/src/components/organisms/mobileHeader.module.scss
@@ -5,7 +5,6 @@
     top: 0;
     display: flex;
     flex-direction: column;
-    margin-bottom: 32px;
     z-index: 10;
     background: $ts-cream;
 }
@@ -29,9 +28,9 @@
 
 .mobileSubnavWrapper {
     position: absolute;
-    top: 100%;
     left: 0;
     right: 0;
+    bottom: 0;
     background: $ts-cream;
 }
 

--- a/src/components/templates/andNavigation.module.scss
+++ b/src/components/templates/andNavigation.module.scss
@@ -15,22 +15,29 @@
 }
 
 .content {
-	flex: 0 1 100vw;
-	padding: 24px calc(24px + env(safe-area-inset-right)) 24px calc(24px + env(safe-area-inset-left));
-	max-width: 100vw;
-	margin: 0 auto;
+	--maxWidth: 100vw;
 
 	@media (min-width: $content-maxWidth-sm) {
-		max-width: $content-maxWidth-sm;
+		--maxWidth: #{$content-maxWidth-sm};
 	}
 
 	@media (min-width: $breakpoint-md) {
-		max-width: 100vw;
+		--maxWidth: 100vw;
 	}
 
 	@media (min-width: $content-maxWidth) {
-		max-width: $content-maxWidth;
+		--maxWidth: #{$content-maxWidth};
 	}
+
+	--maxWidthPadding: calc((100vw - var(--maxWidth)) / 2);
+
+	flex: 0 1 100vw;
+	padding-top: 24px;
+	padding-bottom: 24px;
+	padding-right: calc(24px + env(safe-area-inset-right) + var(--maxWidthPadding));
+	padding-left: calc(24px + env(safe-area-inset-left) + var(--maxWidthPadding));
+	height: 100vh;
+	overflow: scroll;
 }
 
 .searchBox {
@@ -43,19 +50,11 @@
 
 @media (min-width: $breakpoint-lg) {
 	.content {
-		flex: 0 0 100vw;
-		padding-left: #{$sidebar-width + 24px};
 		display: flex;
 		flex-direction: column;
 	}
 
 	.searchBox.searchBox {
 		display: inherit;
-	}
-}
-
-@media (min-width: $breakpoint-xl) {
-	.content {
-		padding-left: #{$sidebar-width + 35px};
 	}
 }

--- a/src/components/templates/andNavigation.tsx
+++ b/src/components/templates/andNavigation.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 
 import LanguageAlternativesAlert from '@components/molecules/languageAlternativesAlert';
 import SearchBar from '@components/molecules/searchBar';
@@ -24,12 +24,13 @@ export default function AndNavigation({
 	const shouldShowSearch =
 		pathname.includes('/[language]/discover') ||
 		pathname.includes('/[language]/search');
+	const scrollRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => setTerm(param), [param, pathname]);
 
 	return (
 		<div className={styles.positioner}>
-			<MobileHeader setShowingMenu={setShowingMenu} />
+			<MobileHeader scrollRef={scrollRef} setShowingMenu={setShowingMenu} />
 			<div className={styles.wrapper}>
 				<div className={styles.base}>
 					<Drawer
@@ -38,7 +39,7 @@ export default function AndNavigation({
 						onSearchChange={(v) => setTerm(v)}
 						searchTerm={term}
 					/>
-					<div className={styles.content}>
+					<div ref={scrollRef} className={styles.content}>
 						<LanguageAlternativesAlert />
 						<SearchBar
 							term={term}


### PR DESCRIPTION
This PR refactors AndNavigation to localize its layout to its subtree. Previous to these changes AndNavigation and its children relied on body scroll position. After these changes, AndNavigation manages its own scroll context. These changes also bring the desktop navigation sidebar into the standard flex layout rather than positioning it as fixed.

These changes should not create any user-visible changes in site behavior.

These changes are for the purpose of making it easier to modify search bar behavior in the future.